### PR TITLE
Bugfix: cannot get version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ARCHIVE=$(CURDIR)/$(PROJECT)-$(VERSION).tar.gz
 
 SANJI_VER=1.0
 
-INSTALL_DIR=$(DESTDIR)/usr/lib/sanji-$(SANJI_VER)/$(PROJECT)
+INSTALL_DIR=$(DESTDIR)/usr/lib/sanji-$(SANJI_VER)/$(NAME)
 
 STAGING_DIR=$(CURDIR)/staging
 

--- a/build-deb/debian/changelog
+++ b/build-deb/debian/changelog
@@ -1,3 +1,11 @@
+sanji-bundle-status (0.9.13-1) unstable; urgency=low
+
+  * Bugfix: version cannot be retrieved
+  * Change install target direction from "sanji-bundle-status" to
+    "status"
+
+ -- Aeluin Chen <aeluin.chen@moxa.com>  Tue, 16 Sep 2015 05:30:10 +0800
+
 sanji-bundle-status (0.9.12-1) unstable; urgency=low
 
   * Add 5% on disk usage; filesystems reserve 5% space for use only the root

--- a/bundle.json
+++ b/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "status",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "author": "Aeluin Chen",
   "email": "aeluin.chen@moxa.com",
   "description": "Provide system status",

--- a/status.py
+++ b/status.py
@@ -59,8 +59,9 @@ class Status(Sanji):
 
         # find product name
         try:
-            output = sh.grep(sh.dpkg("-l"), "mxcloud")
-            self.product = output.split()[1]
+            output = sh.grep(sh.dpkg("--get-selections"), "-E",
+                             "mxcloud.*install")
+            self.product = output.split()[0]
         except:
             self.product = None
 
@@ -102,7 +103,7 @@ class Status(Sanji):
         try:
             pkg_info = sh.dpkg("-s", self.product)
 
-            match = re.search(r"Version: (\S+)", pkg_info)
+            match = re.search(r"Version: (\S+)", str(pkg_info))
             if match:
                 return match.group(1)
         except:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -74,7 +74,7 @@ class TestStatusClass(unittest.TestCase):
         init
         """
         mock_grep.return_value = \
-            "ii uc8100-mxcloud-cg 0.1.2-1 all mxcloud package for ..."
+            "uc8100-mxcloud-cg install"
         self.bundle.init()
         self.assertEqual(self.bundle.product, "uc8100-mxcloud-cg")
 


### PR DESCRIPTION
Bugfix: `dpkg -l` cannot full package name in console, that will cause version cannot be retrieved.
